### PR TITLE
Make optimizer compatible with Apple Silicon MPS

### DIFF
--- a/lion_pytorch/lion_pytorch.py
+++ b/lion_pytorch/lion_pytorch.py
@@ -17,12 +17,12 @@ def update_fn(p, grad, exp_avg, lr, wd, beta1, beta2):
 
     # weight update
 
-    update = exp_avg.clone().lerp_(grad, 1 - beta1).sign_()
+    update = exp_avg.clone().mul_(beta1).add(grad, alpha = 1 - beta1).sign_()
     p.add_(update, alpha = -lr)
 
     # decay the momentum running average coefficient
 
-    exp_avg.lerp_(grad, 1 - beta2)
+    exp_avg.mul_(beta2).add_(grad, alpha = 1 - beta2)
 
 # class
 


### PR DESCRIPTION
It seems like the `tensor.lerp_()` function, as also noted in this issue: https://github.com/pytorch/pytorch/issues/77764

This PR simply replaces all `.lerp_()` calls with `.mul_()` followed by `.add_()`, which should be very close in performance while also being compatible with the MPS backend for Apple Silicon machines.