### PR TITLE
Fix in-place modification when autotuning triton Lion update

### DIFF
--- a/lion_pytorch/triton.py
+++ b/lion_pytorch/triton.py
@@ -7,19 +7,12 @@ except ImportError as e:
     print('triton is not installed, please install by running `pip install triton -U --pre`')
     exit()
 
-# clone param and exp_avg before autotuning takes place
-# as those are updated in-place
-
-def clone_inplace_updated_params(nargs):
-    nargs['p_ptr'] = nargs['p_ptr'].clone()
-    nargs['exp_avg_ptr'] = nargs['exp_avg_ptr'].clone()
-
 # triton cuda kernel
 
 @triton.autotune(configs = [
-    triton.Config({'BLOCK_SIZE': 128}, num_warps = 4, pre_hook = clone_inplace_updated_params),
-    triton.Config({'BLOCK_SIZE': 1024}, num_warps = 8, pre_hook = clone_inplace_updated_params),
-], key = ['n_elements'])
+    triton.Config({'BLOCK_SIZE': 128}, num_warps = 4),
+    triton.Config({'BLOCK_SIZE': 1024}, num_warps = 8),
+], key = ['n_elements'], restore_value=['p_ptr', 'exp_avg_ptr'])
 @triton.jit
 def update_fn_kernel(
     p_ptr,


### PR DESCRIPTION
Currently the autotuning modifies the parameters in place and so produces incorrect results. 

You can verify this via 
```python
import torch
import lion_pytorch.triton as lpt
from lion_pytorch.lion_pytorch import update_fn

# try both the triton and torch implementations
for update in [lpt.update_fn, update_fn]:
    param = torch.ones(5, dtype=torch.float32, device="cuda:0")
    grad = torch.full_like(param, fill_value=1e-3, dtype=torch.float32, device="cuda:0")
    exp = torch.zeros_like(param, dtype=torch.float32, device="cuda:0")
    update(p=param, grad=grad, exp_avg=exp, lr=1e-3, wd=0, beta1=0.9, beta2=0.99)
    print(f"Set param to {param}")
```

Running this script gives different results 
a) between the triton and non-triton implementations and 
b) between multiple triton runs of the same script

This PR resolves this by using the `restore_value` feature in `triton.autotune` which restores the values back after autotuning completes. And thereby avoids the issues of in-place modification.